### PR TITLE
ensure 64bit type for bitfield

### DIFF
--- a/kdq.h
+++ b/kdq.h
@@ -1,12 +1,13 @@
 #ifndef __AC_KDQ_H
 #define __AC_KDQ_H
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
 #define __KDQ_TYPE(type) \
 	typedef struct { \
-		size_t front:58, bits:6, count, mask; \
+		uint64_t front:58, bits:6, count, mask; \
 		type *a; \
 	} kdq_##type##_t;
 


### PR DESCRIPTION
`size_t` is not guaranteed to be >= 64 bit in length. However, this is expected in `kdq.h`:

``` C
#define __KDQ_TYPE(type) \
    typedef struct { \
        size_t front:58, bits:6, count, mask; \
        type *a; \
    } kdq_##type##_t;
```

This patch fixes building minimap on architectures where it's generally less (i.e. '32-bit' platforms), where otherwise:

```
$ uname -m
i686
$ make
gcc -c -g -Wall -O2 -Wc++-compat -Wno-unused-function  -I. main.c -o main.o
gcc -c -g -Wall -O2 -Wc++-compat -Wno-unused-function  -I. kthread.c -o kthread.o
gcc -c -g -Wall -O2 -Wc++-compat -Wno-unused-function  -I. misc.c -o misc.o
gcc -c -g -Wall -O2 -Wc++-compat -Wno-unused-function  -I. bseq.c -o bseq.o
gcc -c -g -Wall -O2 -Wc++-compat -Wno-unused-function  -I. sketch.c -o sketch.o
gcc -c -g -Wall -O2 -Wc++-compat -Wno-unused-function  -I. sdust.c -o sdust.o
sdust.c:20:1: error: width of ‘front’ exceeds its type
make: *** [sdust.o] Error 1
```
